### PR TITLE
Fix out of bounds array indexing

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -343,7 +343,7 @@ ndpi_enable_protocols (const struct xt_ndpi_mtinfo*info)
 				spin_lock_bh (&ipq_lock);
 
 				//Force http or ssl detection for webserver host requests
-	                        if (nfndpi_protocols_http[i]) {
+	                        if (nfndpi_protocols_http[i-1]) {
 					if (ndpi_struct->proto_defaults[NDPI_PROTOCOL_DNS].protoIdx == 0)
 						 NDPI_ADD_PROTOCOL_TO_BITMASK(protocols_bitmask, NDPI_PROTOCOL_DNS);
 					if (ndpi_struct->proto_defaults[NDPI_PROTOCOL_HTTP].protoIdx == 0)
@@ -775,7 +775,7 @@ static int __init ndpi_mt_init(void)
                 goto err_out;
 	}
 
-        for (i = 0; i <= NDPI_LAST_IMPLEMENTED_PROTOCOL; i++){
+        for (i = 0; i < NDPI_LAST_IMPLEMENTED_PROTOCOL; i++){
                 atomic_set (&protocols_cnt[i], 0);
 
                 // Set HTTP based protocols


### PR DESCRIPTION
These appear to be bugs in the upstream project.

- `protocols_cnt[]` and `nfndpi_protocols_http[]` are both static in `main.c` and declared with `NDPI_LAST_IMPLEMENTED_PROTOCOL` as their size.
- Every iteration of these arrays should be `(i = 0; i < NDPI_LAST_IMPLEMENTED_PROTOCOL; ++i)`
- There are three such iterations
  - `ndpi_enable_protocols()`
    - This uses i = 1 and i <= NDPI_LAST_IMPLEMENTED_PROTOCOL to index
      - `ndpi_struct->proto_defaults[i]` (line 342)
      - `nfndpi_protocols_http[i]` (line 346) **This overruns array bounds**
      - `protocols_cnt[i-1]` (line 355)
      - `protocols_bitmask`, i (line 356)
  - `ndpi_disable_protocols()`
    - This uses `i = 1` and `i <= NDPI_LAST_IMPLEMENTED_PROTOCOL` to index
      - `protocols_cnt[i-1]` (line 375)
      - `protocols_bitmask`, i (line 376)
  - `ndpi_mt_init()`
    - This uses `i = 0` and `i <= NDPI_LAST_IMPLEMENTED_PROTOCOL` to index (**NOTE starts at 0**)
      - `protocols_cnt[i]` (line 779) **This overruns array bounds**
      - `nfndpi_protocols_http[i]` (lines 782, 783) **This overruns array bounds**

It seems `protocols_cnt[]` is always indexed starting at 0 (lines 355, 375, 779)

It seems that the bitmask is always indexed starting at 1 (lines 356, 376)

It seems that `protocols_cnt[]` and `nfndpi_protocols_http[]` should be indexed the same.

This commit:

- Changes line 346 to index `nfndpi_protocols_http[]` by `i-1` in a 1-based loop
- Changes the loop in `ndpi_mt_init` to use `<` so it iterates over 0 to less than size as most C loops do.